### PR TITLE
Add profile views counter to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
   <em>San Francisco Bay Area, CA · Open to relocation · Authorized to work in the USA</em>
 </p>
 
+<p align="center">
+  <img src="https://komarev.com/ghpvc/?username=HaseebKhanYT&style=for-the-badge&color=blueviolet&label=Profile+Views" alt="Profile views" />
+</p>
+
 ---
 
 ## About


### PR DESCRIPTION
## Summary
- Adds a profile views counter badge (komarev.com/ghpvc) centered just below the location line, before the first `---` separator
- Placement keeps it part of the profile-metadata block without disturbing the recruiter scan path (headline → contact → location → about)

## Test plan
- [ ] View rendered README on GitHub after merge — confirm badge displays and increments on subsequent loads